### PR TITLE
Make Rails5 rspec codemod work for xhr requests

### DIFF
--- a/lib/rails5/spec_converter/hash_rewriter.rb
+++ b/lib/rails5/spec_converter/hash_rewriter.rb
@@ -5,13 +5,13 @@ class HashRewriter
 
   attr_reader :hash_node, :original_indent
 
-  def initialize(content:, hash_node:, original_indent:, options:)
+  def initialize(content:, hash_node:, original_indent:, options:, xhr_node: nil)
     @options = options
     @content = content
     @hash_node = hash_node
     @original_indent = original_indent
     @textifier = NodeTextifier.new(@content)
-    partition_params(@hash_node)
+    partition_params(@hash_node, xhr_node)
   end
 
   def rewritten_params_hash
@@ -66,7 +66,7 @@ class HashRewriter
       )
     end
 
-    rewritten_hashes.join(first_joiner_between_pairs)
+    rewritten_hashes.join(first_joiner_between_pairs || ", ")
   end
 
   def should_rewrite_hash?
@@ -89,10 +89,11 @@ class HashRewriter
 
   private
 
-  def partition_params(hash_node)
+  def partition_params(hash_node, xhr_node)
     @pairs_that_belong_in_params = []
     @pairs_that_belong_outside_params = []
 
+    return unless hash_node
     hash_node.children.each do |pair|
       key = pair.children[0].children[0]
 
@@ -101,6 +102,9 @@ class HashRewriter
       else
         @pairs_that_belong_in_params << pair
       end
+    end
+    if xhr_node
+      @pairs_that_belong_outside_params << xhr_node.children.first
     end
   end
 

--- a/lib/rails5/spec_converter/text_transformer.rb
+++ b/lib/rails5/spec_converter/text_transformer.rb
@@ -46,7 +46,6 @@ module Rails5
           end
           next unless args.length > 0
           next unless target.nil? && HTTP_VERBS.include?(verb)
-          puts target, verb, action, *args
 
           if args[0].hash_type?
             if args[0].children.length == 0

--- a/lib/rails5/spec_converter/text_transformer.rb
+++ b/lib/rails5/spec_converter/text_transformer.rb
@@ -1,4 +1,5 @@
 require 'parser/current'
+require 'byebug'
 require 'astrolabe/builder'
 require 'rails5/spec_converter/test_type_identifier'
 require 'rails5/spec_converter/text_transformer_options'
@@ -31,28 +32,25 @@ module Rails5
         end
 
         root_node.each_node(:send) do |node|
-          target, verb, action, *args = node.children
+          children = node.children
+          next unless children.length > 1
+          if children[1] == :xhr
+            target, xhr, verb_expr, action, *args = children
+            next unless xhr && verb_expr.sym_type?
+            verb = verb_expr.children[0]
+            replace_xhr_verb(node, verb)
+            xhr_node = Parser::CurrentRuby.parse("{xhr: true}")
+          else
+            xhr = nil
+            target, verb, action, *args = children
+          end
           next unless args.length > 0
           next unless target.nil? && HTTP_VERBS.include?(verb)
+          puts target, verb, action, *args
 
           if args[0].hash_type?
             if args[0].children.length == 0
               wrap_arg(args[0], 'params')
-            else
-              next if looks_like_route_definition?(args[0])
-              next if has_key?(args[0], :params)
-
-              hash_rewriter = HashRewriter.new(
-                content: @content,
-                options: @options,
-                hash_node: args[0],
-                original_indent: line_indent(node)
-              )
-
-              @source_rewriter.replace(
-                args[0].loc.expression,
-                hash_rewriter.rewritten_params_hash
-              ) if hash_rewriter.should_rewrite_hash?
             end
           elsif args[0].nil_type? && args.length > 1
             nil_arg_range = Parser::Source::Range.new(
@@ -66,6 +64,21 @@ module Rails5
           end
 
           wrap_extra_positional_args!(args) if args.length > 1
+
+          next if looks_like_route_definition?(args[0])
+          next if has_key?(args[0], :params)
+          hash_rewriter = HashRewriter.new(
+            content: @content,
+            options: @options,
+            hash_node: args[0],
+            original_indent: line_indent(node),
+            xhr_node: xhr_node
+          )
+
+          @source_rewriter.replace(
+            args[0].loc.expression,
+            hash_rewriter.rewritten_params_hash
+          ) if hash_rewriter.should_rewrite_hash?
         end
 
         @source_rewriter.process
@@ -116,6 +129,15 @@ module Rails5
           node_source = "{ #{node_source} }"
         end
         @source_rewriter.replace(node_loc, "#{key}: #{node_source}")
+      end
+
+      def replace_xhr_verb(node, verb)
+        node_loc = node.loc.expression
+        node_source = node_loc.source
+        spacing = node_source.gsub(/\Axhr([\s(]*):.*/, '\1')
+        verb_size = node_source[/\Axhr([\s(]*):#{verb},\s*/].size
+        node_loc = node_loc.resize(verb_size)
+        @source_rewriter.replace(node_loc, verb.to_s + spacing)
       end
 
       def line_indent(node)

--- a/spec/rails5/text_transformer_spec.rb
+++ b/spec/rails5/text_transformer_spec.rb
@@ -416,6 +416,50 @@ describe Rails5::SpecConverter::TextTransformer do
     end
   end
 
+  describe 'xhr requests' do
+    it 'converts xhr requests to requests with xhr: true' do
+      result = transform(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          xhr :get, :index, some: param
+        end
+      RUBY
+
+      expect(result).to eq(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          get :index, params: { some: param }, xhr: true
+        end
+      RUBY
+    end
+
+    it 'converts existing params named xhr to hash' do
+      result = transform(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          get :index, xhr: true
+        end
+      RUBY
+
+      expect(result).to eq(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          get :index, params: { xhr: true }
+        end
+      RUBY
+    end
+
+    it 'converts xhr requests with existing xhr: true' do
+      result = transform(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          xhr :get, :index, xhr: true
+        end
+      RUBY
+
+      expect(result).to eq(<<-RUBY.strip_heredoc)
+        let(:perform_request) do
+          get :index, params: { xhr: true }, xhr: true
+        end
+      RUBY
+    end
+  end
+
   describe 'optional configuration' do
     it 'allows a custom indent to be set' do
       options = TextTransformerOptions.new


### PR DESCRIPTION
Add support for converting deprecated `xhr :verb` requests into `verb
... xhr: true`

Note that this will not work for the case where there are no prexisting parameters